### PR TITLE
WIP: Add Kazakh language to boot menu

### DIFF
--- a/Input/common/isolinux/languages
+++ b/Input/common/isolinux/languages
@@ -28,6 +28,7 @@ is_IS
 it_IT
 he_IL
 ja_JP
+kk_KZ
 ko_KR
 lv_LV
 lt_LT

--- a/src/menu_lang.inc
+++ b/src/menu_lang.inc
@@ -62,6 +62,7 @@
   [ "it_IT"  "it"       false "Italiano"                                      "it" ] % Italian
   [ "ja_JP"  "jp"       false "日本語"                                        "jp" ] % Japanese
   [ "jv_ID"  "us"       false "Basa Jawa"                                     "us" ] % Javanese
+  [ "kk_KZ"  "us"       false "Қазақша"                                       "us" ] % Kazakh
   [ "km_KH"  "khmer"    false "Khmer"                                         "kh" ] % Khmer
   [ "ko_KR"  "kr"       false "한글"                                          "kr" ] % Korean
   [ "ky_KG"  "us"       false "Кыргызча"                                      "kg" ] % Kirghiz


### PR DESCRIPTION
With the PO translation file merge from Transifex, I am adding Kazakh language to start menu.

Now there is what I didn't get: the last parameter in square brackets - is it the keyboard layout for X windows system?